### PR TITLE
Remove unnecessary DB clean up

### DIFF
--- a/mdtest/db.go
+++ b/mdtest/db.go
@@ -42,11 +42,6 @@ func AccessTestDB(
 	}
 
 	consumer(db)
-
-	err = dbMigrationTool.MigrateDown(db, dbMigrationRoot)
-	if err != nil {
-		panic(err)
-	}
 }
 
 func resetDatabase(db *sql.DB, dbMigrationRoot string, dbMigrationTool fw.DBMigrationTool) error {


### PR DESCRIPTION
DB integration tests take long time to execute. Removing unnecessary database clean up procedure reduces test run time by half.

Reset | Migrate Up | Migrate Down | Time
-- | -- | -- | --
Yes | Yes | Yes | 135.919s
Yes | Yes | No | 73.122s

