### PR TITLE
Extract out relay handler

### DIFF
--- a/fw/graphql.go
+++ b/fw/graphql.go
@@ -1,13 +1,13 @@
 package fw
 
-type Resolver = interface{}
+type Resolver interface{}
 
-type GraphQlAPI interface {
+type GraphQLAPI interface {
 	GetSchema() string
 	GetResolver() Resolver
 }
 
-type Scalar interface {
+type GraphQLScalar interface {
 	ImplementsGraphQLType(name string) bool
 	UnmarshalGraphQL(input interface{}) error
 	MarshalJSON() ([]byte, error)

--- a/modern/mdenv/env.go
+++ b/modern/mdenv/env.go
@@ -3,6 +3,7 @@ package mdenv
 import (
 	"log"
 	"os"
+	"path"
 
 	"github.com/byliuyang/app/fw"
 	"github.com/joho/godotenv"
@@ -22,7 +23,12 @@ func (g GoDotEnv) GetEnv(key string, defaultValue string) string {
 }
 
 func (g GoDotEnv) AutoLoadDotEnvFile() {
-	_, err := os.Stat(".env")
+	workDir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = os.Stat(path.Join(workDir, ".env"))
 	if os.IsNotExist(err) {
 		return
 	}

--- a/modern/mdenv/env.go
+++ b/modern/mdenv/env.go
@@ -3,7 +3,6 @@ package mdenv
 import (
 	"log"
 	"os"
-	"path"
 
 	"github.com/byliuyang/app/fw"
 	"github.com/joho/godotenv"
@@ -23,12 +22,7 @@ func (g GoDotEnv) GetEnv(key string, defaultValue string) string {
 }
 
 func (g GoDotEnv) AutoLoadDotEnvFile() {
-	workDir, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-
-	_, err = os.Stat(path.Join(workDir, ".env"))
+	_, err := os.Stat(".env")
 	if os.IsNotExist(err) {
 		return
 	}


### PR DESCRIPTION
Google Cloud Function has its own way of initializing http server. Extracting out relay handler allows Google Cloud Function to invoke the HTTP handler directly.